### PR TITLE
Fix dialyzer warning

### DIFF
--- a/src/erlzk.erl
+++ b/src/erlzk.erl
@@ -358,7 +358,7 @@ multi(Pid, Ops) ->
 %% v3.4.5 or current developing v3.5.0 (ZooKeeper added it again).
 %%
 %% @see create/5
--spec create2(pid(), nonempty_string()) -> {ok, Path::nonempty_string()} | {error, atom()}.
+-spec create2(pid(), nonempty_string()) -> {ok, {Path::nonempty_string(), #stat{}}} | {error, atom()}.
 create2(Pid, Path) ->
     create2(Pid, Path, <<>>, [?ZK_ACL_OPEN_ACL_UNSAFE], persistent).
 


### PR DESCRIPTION
Fix warning
```
>> dialyzer -Wunderspecs  ebin
  Checking whether the PLT /home/kpi/.dialyzer_plt is up-to-date... yes
  Proceeding with analysis...
erlzk.erl:361: The specification for erlzk:create2/2 states that the function might also return {'ok',nonempty_string()} but the inferred return is {'error',atom()} | {'ok',{nonempty_string(),{'stat','undefined' | non_neg_integer(),'undefined' | non_neg_integer(),'undefined' | non_neg_integer(),'undefined' | non_neg_integer(),'undefined' | non_neg_integer(),'undefined' | non_neg_integer(),'undefined' | non_neg_integer(),'undefined' | non_neg_integer(),'undefined' | non_neg_integer(),'undefined' | non_neg_integer(),'undefined' | non_neg_integer()}}}
 done in 0m1.96s
done (warnings were emitted)
```
