### PR TITLE
Use iodata in path instead of nonempty_string

### DIFF
--- a/src/erlzk.erl
+++ b/src/erlzk.erl
@@ -358,7 +358,7 @@ multi(Pid, Ops) ->
 %% v3.4.5 or current developing v3.5.0 (ZooKeeper added it again).
 %%
 %% @see create/5
--spec create2(pid(), nonempty_string()) -> {ok, Path::nonempty_string()} | {error, atom()}.
+-spec create2(pid(), nonempty_string()) -> {ok, {Path::nonempty_string(), #stat{}}} | {error, atom()}.
 create2(Pid, Path) ->
     create2(Pid, Path, <<>>, [?ZK_ACL_OPEN_ACL_UNSAFE], persistent).
 

--- a/src/erlzk.erl
+++ b/src/erlzk.erl
@@ -98,16 +98,16 @@ close(Pid) ->
 %% ===================================================================
 %% @doc Create a node with the given path, return the actual path of the node.
 %% @see create/5
--spec create(pid(), nonempty_string()) -> {ok, Path::nonempty_string()} | {error, atom()}.
+-spec create(pid(), nonempty_string()) -> {ok, Path::iodata()} | {error, atom()}.
 create(Pid, Path) ->
     create(Pid, Path, <<>>, [?ZK_ACL_OPEN_ACL_UNSAFE], persistent).
 
 %% @doc Create a node with the given path, return the actual path of the node.
 %% @see create/5
--spec create(pid(), nonempty_string(), binary())      -> {ok, Path::nonempty_string()} | {error, atom()};
-            (pid(), nonempty_string(), acl())         -> {ok, Path::nonempty_string()} | {error, atom()};
-            (pid(), nonempty_string(), [acl()])       -> {ok, Path::nonempty_string()} | {error, atom()};
-            (pid(), nonempty_string(), create_mode()) -> {ok, nonempty_string()} | {error, atom()}.
+-spec create(pid(), iodata(), binary())      -> {ok, Path::nonempty_string()} | {error, atom()};
+            (pid(), iodata(), acl())         -> {ok, Path::nonempty_string()} | {error, atom()};
+            (pid(), iodata(), [acl()])       -> {ok, Path::nonempty_string()} | {error, atom()};
+            (pid(), iodata(), create_mode()) -> {ok, nonempty_string()} | {error, atom()}.
 create(Pid, Path, Data) when is_binary(Data) ->
     create(Pid, Path, Data, [?ZK_ACL_OPEN_ACL_UNSAFE], persistent);
 create(Pid, Path, Acl) when is_tuple(Acl) orelse is_list(Acl) ->
@@ -117,11 +117,11 @@ create(Pid, Path, CreateMode) when is_atom(CreateMode) ->
 
 %% @doc Create a node with the given path, return the actual path of the node.
 %% @see create/5
--spec create(pid(), nonempty_string(), binary(), acl())         -> {ok, Path::nonempty_string()} | {error, atom()};
-            (pid(), nonempty_string(), binary(), [acl()])       -> {ok, Path::nonempty_string()} | {error, atom()};
-            (pid(), nonempty_string(), binary(), create_mode()) -> {ok, nonempty_string()} | {error, atom()};
-            (pid(), nonempty_string(), acl(), create_mode())    -> {ok, nonempty_string()} | {error, atom()};
-            (pid(), nonempty_string(), [acl()], create_mode())  -> {ok, nonempty_string()} | {error, atom()}.
+-spec create(pid(), iodata(), binary(), acl())         -> {ok, Path::nonempty_string()} | {error, atom()};
+            (pid(), iodata(), binary(), [acl()])       -> {ok, Path::nonempty_string()} | {error, atom()};
+            (pid(), iodata(), binary(), create_mode()) -> {ok, nonempty_string()} | {error, atom()};
+            (pid(), iodata(), acl(), create_mode())    -> {ok, nonempty_string()} | {error, atom()};
+            (pid(), iodata(), [acl()], create_mode())  -> {ok, nonempty_string()} | {error, atom()}.
 create(Pid, Path, Data, Acl) when is_binary(Data) andalso (is_tuple(Acl) orelse is_list(Acl)) ->
     create(Pid, Path, Data, Acl, persistent);
 create(Pid, Path, Data, CreateMode) when is_binary(Data) andalso is_atom(CreateMode) ->
@@ -161,8 +161,8 @@ create(Pid, Path, Acl, CreateMode) when (is_tuple(Acl) orelse is_list(Acl)) anda
 %% If the call is successful, will trigger all the watches left on the
 %% node of the given path by {@link exists/3} and {@link get_data/3},
 %% and the watches left on the parent node by {@link get_children/3}.
--spec create(pid(), nonempty_string(), binary(), acl(), create_mode())   -> {ok, nonempty_string()} | {error, atom()};
-            (pid(), nonempty_string(), binary(), [acl()], create_mode()) -> {ok, nonempty_string()} | {error, atom()}.
+-spec create(pid(), iodata(), binary(), acl(), create_mode())   -> {ok, nonempty_string()} | {error, atom()};
+            (pid(), iodata(), binary(), [acl()], create_mode()) -> {ok, nonempty_string()} | {error, atom()}.
 create(Pid, Path, Data, Acl, CreateMode) when is_binary(Data) andalso is_tuple(Acl) andalso is_atom(CreateMode) ->
     create(Pid, Path, Data, [Acl], CreateMode);
 create(Pid, Path, Data, Acl, CreateMode) when is_binary(Data) andalso is_list(Acl) andalso is_atom(CreateMode) ->
@@ -170,7 +170,7 @@ create(Pid, Path, Data, Acl, CreateMode) when is_binary(Data) andalso is_list(Ac
 
 %% @doc Delete the node with the given path.
 %% @see delete/3
--spec delete(pid(), nonempty_string()) -> ok | {error, atom()}.
+-spec delete(pid(), iodata()) -> ok | {error, atom()}.
 delete(Pid, Path) ->
     delete(Pid, Path, -1).
 
@@ -192,13 +192,13 @@ delete(Pid, Path) ->
 %% If the call is successful, will trigger all the watches left on the node of
 %% the given path by {@link exists/3} and {@link get_data/3} and {@link get_children/3},
 %% and the watches left on the parent node by {@link get_children/3}.
--spec delete(pid(), nonempty_string(), integer()) -> ok | {error, atom()}.
+-spec delete(pid(), iodata(), integer()) -> ok | {error, atom()}.
 delete(Pid, Path, Version) ->
     erlzk_conn:delete(Pid, Path, Version).
 
 %% @doc Checks the existence of the node of the given path, return the stat of the node.
 %% @see exists/3
--spec exists(pid(), nonempty_string()) -> {ok, #stat{}} | {error, atom()}.
+-spec exists(pid(), iodata()) -> {ok, #stat{}} | {error, atom()}.
 exists(Pid, Path) ->
     erlzk_conn:exists(Pid, Path, false).
 
@@ -211,13 +211,13 @@ exists(Pid, Path) ->
 %% If the call is successful, a watch will be left on the node with the given path.
 %% The watch will be triggered by a successful operation that {@link set_data/4} on the node,
 %% or {@link create/5} / {@link delete/3} the node.
--spec exists(pid(), nonempty_string(), pid()) -> {ok, #stat{}} | {error, atom()}.
+-spec exists(pid(), iodata(), pid()) -> {ok, #stat{}} | {error, atom()}.
 exists(Pid, Path, Watcher) ->
     erlzk_conn:exists(Pid, Path, true, Watcher).
 
 %% @doc Return the data and the stat of the node of the given path.
 %% @see get_data/3
--spec get_data(pid(), nonempty_string()) -> {ok, {binary(), #stat{}}} | {error, atom()}.
+-spec get_data(pid(), iodata()) -> {ok, {binary(), #stat{}}} | {error, atom()}.
 get_data(Pid, Path) ->
     erlzk_conn:get_data(Pid, Path, false).
 
@@ -232,13 +232,13 @@ get_data(Pid, Path) ->
 %% If the call is successful, a watch will be left on the node with the given path.
 %% The watch will be triggered by a successful operation that {@link set_data/4} on the node,
 %% or {@link create/5} / {@link delete/3} the node.
--spec get_data(pid(), nonempty_string(), pid()) -> {ok, {binary(), #stat{}}} | {error, atom()}.
+-spec get_data(pid(), iodata(), pid()) -> {ok, {binary(), #stat{}}} | {error, atom()}.
 get_data(Pid, Path, Watcher) ->
     erlzk_conn:get_data(Pid, Path, true, Watcher).
 
 %% @doc Set the data for the node of the given path, return the stat of the node.
 %% @see set_data/4
--spec set_data(pid(), nonempty_string(), binary()) -> {ok, #stat{}} | {error, atom()}.
+-spec set_data(pid(), iodata(), binary()) -> {ok, #stat{}} | {error, atom()}.
 set_data(Pid, Path, Data) ->
     set_data(Pid, Path, Data, -1).
 
@@ -257,7 +257,7 @@ set_data(Pid, Path, Data) ->
 %%
 %% If the call is successful, will trigger all the watches on the node of the given path
 %% left by {@link exists/3} and {@link get_data/3} calls.
--spec set_data(pid(), nonempty_string(), binary(), integer()) -> {ok, #stat{}} | {error, atom()}.
+-spec set_data(pid(), iodata(), binary(), integer()) -> {ok, #stat{}} | {error, atom()}.
 set_data(Pid, Path, Data, Version) when is_binary(Data) ->
     erlzk_conn:set_data(Pid, Path, Data, Version).
 
@@ -266,14 +266,14 @@ set_data(Pid, Path, Data, Version) when is_binary(Data) ->
 %% {error, no_node} will be returned if the node does not exist.
 %%
 %% {error, closed} will be returned during reconnecting.
--spec get_acl(pid(), nonempty_string()) -> {ok, {[acl()], #stat{}}} | {error, atom()}.
+-spec get_acl(pid(), iodata()) -> {ok, {[acl()], #stat{}}} | {error, atom()}.
 get_acl(Pid, Path) ->
     erlzk_conn:get_acl(Pid, Path).
 
 %% @doc Set the ACL of the node of the given path, return the ACL and the stat of the node.
 %% @see set_acl/4
--spec set_acl(pid(), nonempty_string(), acl())   -> {ok, #stat{}} | {error, atom()};
-             (pid(), nonempty_string(), [acl()]) -> {ok, #stat{}} | {error, atom()}.
+-spec set_acl(pid(), iodata(), acl())   -> {ok, #stat{}} | {error, atom()};
+             (pid(), iodata(), [acl()]) -> {ok, #stat{}} | {error, atom()}.
 set_acl(Pid, Path, Acl) ->
     set_acl(Pid, Path, Acl, -1).
 
@@ -288,8 +288,8 @@ set_acl(Pid, Path, Acl) ->
 %% {error, closed} will be returned during reconnecting.
 %%
 %% If the acl is empty or invalid, will return {error, invalid_acl}.
--spec set_acl(pid(), nonempty_string(), acl(), integer())   -> {ok, #stat{}} | {error, atom()};
-             (pid(), nonempty_string(), [acl()], integer()) -> {ok, #stat{}} | {error, atom()}.
+-spec set_acl(pid(), iodata(), acl(), integer())   -> {ok, #stat{}} | {error, atom()};
+             (pid(), iodata(), [acl()], integer()) -> {ok, #stat{}} | {error, atom()}.
 set_acl(Pid, Path, Acl, Version) when is_tuple(Acl) ->
     set_acl(Pid, Path, [Acl], Version);
 set_acl(Pid, Path, Acl, Version) when is_list(Acl) ->
@@ -297,7 +297,7 @@ set_acl(Pid, Path, Acl, Version) when is_list(Acl) ->
 
 %% @doc Return the list of the children of the node of the given path.
 %% @see get_children/3
--spec get_children(pid(), nonempty_string()) -> {ok, [nonempty_string()]} | {error, atom()}.
+-spec get_children(pid(), iodata()) -> {ok, [nonempty_string()]} | {error, atom()}.
 get_children(Pid, Path) ->
     erlzk_conn:get_children(Pid, Path, false).
 
@@ -315,7 +315,7 @@ get_children(Pid, Path) ->
 %%
 %% The list of children returned is not sorted and no guarantee is provided
 %% as to its natural or lexical order.
--spec get_children(pid(), nonempty_string(), pid()) -> {ok, [nonempty_string()]} | {error, atom()}.
+-spec get_children(pid(), iodata(), pid()) -> {ok, [nonempty_string()]} | {error, atom()}.
 get_children(Pid, Path, Watcher) ->
     erlzk_conn:get_children(Pid, Path, true, Watcher).
 
@@ -324,19 +324,19 @@ get_children(Pid, Path, Watcher) ->
 %% {error, closed} will be returned during reconnecting.
 %%
 %% If it is important that multiple client read the same value, call this function before read.
--spec sync(pid(), nonempty_string()) -> {ok, Path::nonempty_string()} | {error, atom()}.
+-spec sync(pid(), iodata()) -> {ok, Path::nonempty_string()} | {error, atom()}.
 sync(Pid, Path) ->
     erlzk_conn:sync(Pid, Path).
 
 %% @doc Return the list of the children and the stat of the node of the given path.
 %% @see get_children/3
--spec get_children2(pid(), nonempty_string()) -> {ok, {[nonempty_string()], #stat{}}} | {error, atom()}.
+-spec get_children2(pid(), iodata()) -> {ok, {[nonempty_string()], #stat{}}} | {error, atom()}.
 get_children2(Pid, Path) ->
     erlzk_conn:get_children2(Pid, Path, false).
 
 %% @doc Return the list of the children and the stat of the node of the given path.
 %% @see get_children/3
--spec get_children2(pid(), nonempty_string(), pid()) -> {ok, {[nonempty_string()], #stat{}}} | {error, atom()}.
+-spec get_children2(pid(), iodata(), pid()) -> {ok, {[nonempty_string()], #stat{}}} | {error, atom()}.
 get_children2(Pid, Path, Watcher) ->
     erlzk_conn:get_children2(Pid, Path, true, Watcher).
 
@@ -358,7 +358,7 @@ multi(Pid, Ops) ->
 %% v3.4.5 or current developing v3.5.0 (ZooKeeper added it again).
 %%
 %% @see create/5
--spec create2(pid(), nonempty_string()) -> {ok, {Path::nonempty_string(), #stat{}}} | {error, atom()}.
+-spec create2(pid(), iodata()) -> {ok, {Path::nonempty_string(), #stat{}}} | {error, atom()}.
 create2(Pid, Path) ->
     create2(Pid, Path, <<>>, [?ZK_ACL_OPEN_ACL_UNSAFE], persistent).
 
@@ -368,10 +368,10 @@ create2(Pid, Path) ->
 %% v3.4.5 or current developing v3.5.0 (ZooKeeper added it again).
 %%
 %% @see create/5
--spec create2(pid(), nonempty_string(), binary())      -> {ok, {Path::nonempty_string(), #stat{}}} | {error, atom()};
-             (pid(), nonempty_string(), acl())         -> {ok, {Path::nonempty_string(), #stat{}}} | {error, atom()};
-             (pid(), nonempty_string(), [acl()])       -> {ok, {Path::nonempty_string(), #stat{}}} | {error, atom()};
-             (pid(), nonempty_string(), create_mode()) -> {ok, {nonempty_string(), #stat{}}} | {error, atom()}.
+-spec create2(pid(), iodata(), binary())      -> {ok, {Path::nonempty_string(), #stat{}}} | {error, atom()};
+             (pid(), iodata(), acl())         -> {ok, {Path::nonempty_string(), #stat{}}} | {error, atom()};
+             (pid(), iodata(), [acl()])       -> {ok, {Path::nonempty_string(), #stat{}}} | {error, atom()};
+             (pid(), iodata(), create_mode()) -> {ok, {nonempty_string(), #stat{}}} | {error, atom()}.
 create2(Pid, Path, Data) when is_binary(Data) ->
     create2(Pid, Path, Data, [?ZK_ACL_OPEN_ACL_UNSAFE], persistent);
 create2(Pid, Path, Acl) when is_tuple(Acl) orelse is_list(Acl) ->
@@ -385,11 +385,11 @@ create2(Pid, Path, CreateMode) when is_atom(CreateMode) ->
 %% v3.4.5 or current developing v3.5.0 (ZooKeeper added it again).
 %%
 %% @see create/5
--spec create2(pid(), nonempty_string(), binary(), acl())         -> {ok, {Path::nonempty_string(), #stat{}}} | {error, atom()};
-             (pid(), nonempty_string(), binary(), [acl()])       -> {ok, {Path::nonempty_string(), #stat{}}} | {error, atom()};
-             (pid(), nonempty_string(), binary(), create_mode()) -> {ok, {nonempty_string(), #stat{}}} | {error, atom()};
-             (pid(), nonempty_string(), acl(), create_mode())    -> {ok, {nonempty_string(), #stat{}}} | {error, atom()};
-             (pid(), nonempty_string(), [acl()], create_mode())  -> {ok, {nonempty_string(), #stat{}}} | {error, atom()}.
+-spec create2(pid(), iodata(), binary(), acl())         -> {ok, {Path::nonempty_string(), #stat{}}} | {error, atom()};
+             (pid(), iodata(), binary(), [acl()])       -> {ok, {Path::nonempty_string(), #stat{}}} | {error, atom()};
+             (pid(), iodata(), binary(), create_mode()) -> {ok, {nonempty_string(), #stat{}}} | {error, atom()};
+             (pid(), iodata(), acl(), create_mode())    -> {ok, {nonempty_string(), #stat{}}} | {error, atom()};
+             (pid(), iodata(), [acl()], create_mode())  -> {ok, {nonempty_string(), #stat{}}} | {error, atom()}.
 create2(Pid, Path, Data, Acl) when is_binary(Data) andalso (is_tuple(Acl) orelse is_list(Acl)) ->
     create2(Pid, Path, Data, Acl, persistent);
 create2(Pid, Path, Data, CreateMode) when is_binary(Data) andalso is_atom(CreateMode) ->
@@ -403,8 +403,8 @@ create2(Pid, Path, Acl, CreateMode) when (is_tuple(Acl) orelse is_list(Acl)) and
 %% v3.4.5 or current developing v3.5.0 (ZooKeeper added it again).
 %%
 %% @see create/5
--spec create2(pid(), nonempty_string(), binary(), acl(), create_mode())   -> {ok, {nonempty_string(), #stat{}}} | {error, atom()};
-             (pid(), nonempty_string(), binary(), [acl()], create_mode()) -> {ok, {nonempty_string(), #stat{}}} | {error, atom()}.
+-spec create2(pid(), iodata(), binary(), acl(), create_mode())   -> {ok, {nonempty_string(), #stat{}}} | {error, atom()};
+             (pid(), iodata(), binary(), [acl()], create_mode()) -> {ok, {nonempty_string(), #stat{}}} | {error, atom()}.
 create2(Pid, Path, Data, Acl, CreateMode) when is_binary(Data) andalso is_tuple(Acl) andalso is_atom(CreateMode) ->
     create2(Pid, Path, Data, [Acl], CreateMode);
 create2(Pid, Path, Data, Acl, CreateMode) when is_binary(Data) andalso is_list(Acl) andalso is_atom(CreateMode) ->

--- a/src/erlzk_conn.erl
+++ b/src/erlzk_conn.erl
@@ -202,7 +202,7 @@ handle_info({tcp, _Port, Packet}, State=#state{chroot=Chroot, ping_interval=Ping
     case Xid of
         -1 -> % watched event
             {EventType, _KeeperState, Path} = erlzk_codec:unpack(watched_event, Body, Chroot),
-            {Receivers, NewWatchers} = find_and_erase_watchers(EventType, Path, Watchers),
+            {Receivers, NewWatchers} = find_and_erase_watchers(EventType, list_to_binary(Path), Watchers),
             send_watched_event(Receivers, EventType),
             {noreply, State#state{zxid=Zxid, watchers=NewWatchers}, PingIntv};
         -2 -> % ping
@@ -395,6 +395,8 @@ notify_monitor_server_state(Monitor, State, Host, Port) ->
             Monitor ! {State, Host, Port}
     end.
 
+store_watcher(Op, Path, Watcher, Watchers) when not is_binary(Path)->
+    store_watcher(Op, iolist_to_binary(Path), Watcher, Watchers);
 store_watcher(Op, Path, Watcher, Watchers) ->
     {Index, DestWatcher} = get_watchers_by_op(Op, Watchers),
     NewWatchers = dict:store(Path, {erlang:now(), Op, Path, Watcher}, DestWatcher),

--- a/test/erlzk_test.erl
+++ b/test/erlzk_test.erl
@@ -348,21 +348,21 @@ watch({ServerList, Timeout, _Chroot, _AuthData}) ->
     ExistCreateWatch = spawn(fun() ->
         receive
             WatchedEvent ->
-                ?assertMatch({exists,"/a",node_created}, WatchedEvent)
+                ?assertMatch({exists,<<"/a">>,node_created}, WatchedEvent)
         end
     end),
     ?assertMatch({error, no_node}, erlzk:exists(Pid, "/a", ExistCreateWatch)),
     GetDataCreateWatch = spawn(fun() ->
         receive
             WatchedEvent ->
-                ?assertMatch({get_data,"/a",node_created}, WatchedEvent)
+                ?assertMatch({get_data,<<"/a">>,node_created}, WatchedEvent)
         end
     end),
     ?assertMatch({error, no_node}, erlzk:get_data(Pid, "/a", GetDataCreateWatch)),
     GetChildCreateWatch = spawn(fun() ->
         receive
             WatchedEvent ->
-                ?assertMatch({get_children,"/",node_children_changed}, WatchedEvent)
+                ?assertMatch({get_children,<<"/">>,node_children_changed}, WatchedEvent)
         end
     end),
     ?assertMatch({ok, ["zookeeper"]}, erlzk:get_children(Pid, "/", GetChildCreateWatch)),
@@ -377,21 +377,21 @@ watch({ServerList, Timeout, _Chroot, _AuthData}) ->
     ExistChangedWatch = spawn(fun() ->
         receive
             WatchedEvent ->
-                ?assertMatch({exists,"/a",node_data_changed}, WatchedEvent)
+                ?assertMatch({exists,<<"/a">>,node_data_changed}, WatchedEvent)
         end
     end),
     ?assertMatch({ok, _Stat}, erlzk:exists(Pid, "/a", ExistChangedWatch)),
     GetDataChangedWatch = spawn(fun() ->
         receive
             WatchedEvent ->
-                ?assertMatch({get_data,"/a",node_data_changed}, WatchedEvent)
+                ?assertMatch({get_data,<<"/a">>,node_data_changed}, WatchedEvent)
         end
     end),
     ?assertMatch({ok, {<<>>, _Stat}}, erlzk:get_data(Pid, "/a", GetDataChangedWatch)),
     GetChildDeleteWatch = spawn(fun() ->
         receive
             WatchedEvent ->
-                ?assertMatch({get_children,"/",node_children_changed}, WatchedEvent)
+                ?assertMatch({get_children,<<"/">>,node_children_changed}, WatchedEvent)
         end
     end),
     {ok, Children} = erlzk:get_children(Pid, "/", GetChildDeleteWatch),
@@ -399,7 +399,7 @@ watch({ServerList, Timeout, _Chroot, _AuthData}) ->
     GetChildDeleteWatch0 = spawn(fun() ->
         receive
             WatchedEvent ->
-                ?assertMatch({get_children,"/a",node_deleted}, WatchedEvent)
+                ?assertMatch({get_children,<<"/a">>,node_deleted}, WatchedEvent)
         end
     end),
     ?assertMatch({ok, []}, erlzk:get_children(Pid, "/a", GetChildDeleteWatch0)),
@@ -416,14 +416,14 @@ watch({ServerList, Timeout, _Chroot, _AuthData}) ->
     ExistDeleteWatch = spawn(fun() ->
         receive
             WatchedEvent ->
-                ?assertMatch({exists,"/a",node_deleted}, WatchedEvent)
+                ?assertMatch({exists,<<"/a">>,node_deleted}, WatchedEvent)
         end
     end),
     ?assertMatch({ok, _Stat}, erlzk:exists(Pid, "/a", ExistDeleteWatch)),
     GetDataDeleteWatch = spawn(fun() ->
         receive
             WatchedEvent ->
-                ?assertMatch({get_data,"/a",node_deleted}, WatchedEvent)
+                ?assertMatch({get_data,<<"/a">>,node_deleted}, WatchedEvent)
         end
     end),
     ?assertMatch({ok, {<<"a">>, _Stat}}, erlzk:get_data(Pid, "/a", GetDataDeleteWatch)),


### PR DESCRIPTION
Hi!
I'd like to suggest support `iodata()` (`iolist() | binary()`) as `Path` variable.
This provide ability to use more concise paths without additional conversions, like:
```erlang
    {ok, Childs} = erlzk:get_children(Zk, ["/brokers/topics/",
                                           TopicName, <<"/partitions">>], ?MODULE),
```
Also is convenient to switch from nonempty_strings in watchers to binaries due binary matching features
```erlang
%{get_data,<<"/brokers/topics/kfkt_test/partitions/47/state">>,node_data_changed}                                                                                             
handle_info({get_data, <<"/brokers/topics/", Rest/binary>>, node_data_changed}, State) ->
    lager:debug("Topic changed: ~p", [Rest]),
    {noreply, State};
```