### PR TITLE
kill_session function and heartbeat handling

### DIFF
--- a/src/erlzk.erl
+++ b/src/erlzk.erl
@@ -18,7 +18,7 @@
 
 -include("erlzk.hrl").
 
--export([start/0, stop/0, connect/2, connect/3, connect/4, close/1]).
+-export([start/0, stop/0, connect/2, connect/3, connect/4, kill_session/1, close/1]).
 -export([create/2, create/3, create/4, create/5, delete/2, delete/3, exists/2, exists/3,
          get_data/2, get_data/3, set_data/3, set_data/4, get_acl/2, set_acl/3, set_acl/4,
          get_children/2, get_children/3, sync/2, get_children2/2, get_children2/3,
@@ -87,6 +87,12 @@ connect(ServerName, ServerList, Timeout) when is_integer(Timeout) ->
               server_list(), pos_integer(), options()) -> {ok, pid()} | {error, atom()}.
 connect(ServerName, ServerList, Timeout, Options) ->
     erlzk_conn_sup:start_conn([ServerName, ServerList, Timeout, Options]).
+
+%% @doc Cause the session to terminate while retaining connection.
+%%  (useful when testing session restart behaviour).
+-spec kill_session(pid()) -> ok.
+kill_session(Pid) ->
+  erlzk_conn:kill_session(Pid).
 
 %% @doc Disconnect to ZooKeeper.
 -spec close(pid()) -> ok.

--- a/src/erlzk_heartbeat.erl
+++ b/src/erlzk_heartbeat.erl
@@ -1,0 +1,73 @@
+%%%-------------------------------------------------------------------
+%%% @author kevinbombadil
+%%% @doc
+%%%   receive heartbeats from the erlzk_conn, send a 'no_heartbest'
+%%%   back to it if we've had to wait too long.
+%%% @end
+%%%-------------------------------------------------------------------
+-module(erlzk_heartbeat).
+
+-behaviour(gen_fsm).
+
+%% API
+-export([start_link/2, beat/1, no_beat/1]).
+
+%% gen_fsm callbacks
+-export([init/1, beating/2, handle_event/3,
+	 handle_sync_event/4, handle_info/3, terminate/3, code_change/4]).
+
+-define(SERVER, ?MODULE).
+
+-record(state, {connection, interval, timer}).
+
+%%%===================================================================
+%%% API
+%%%===================================================================
+start_link(Connection, PartInterval) ->
+    gen_fsm:start_link(?MODULE, [Connection, PartInterval], []).
+
+beat(Pid) ->
+    gen_fsm:send_event(Pid, {beat}).
+
+no_beat(Pid) ->
+    gen_fsm:send_event(Pid, {no_beat}).
+
+
+%%%===================================================================
+%%% gen_fsm callbacks
+%%%===================================================================
+
+init([Connection, PartInterval]) ->
+    Interval = PartInterval * 3,
+    Timer=gen_fsm:start_timer(Interval,no_beat),
+    {ok, beating, #state{connection=Connection, 
+			 timer=Timer,
+			 interval=Interval}}.
+%%--------------------------------------------------------------------
+
+beating({beat},State=#state{interval=Interval, timer=Timer}) ->
+    gen_fsm:cancel_timer(Timer),
+    Timer1=gen_fsm:start_timer(Interval,no_beat),
+    {next_state, beating, State#{timer=Timer1}};
+
+beating({timeout,_Timer,no_beat},State=#state{Connection=connection}) ->
+    erlzk_conn:no_heartbeat(Connection),
+    {stop,shutdown,State}.
+
+%%--------------------------------------------------------------------
+handle_event(_Event, StateName, State) ->
+    {next_state, StateName, State}.
+
+handle_sync_event(_Event, _From, StateName, State) ->
+    Reply = ok,
+    {reply, Reply, StateName, State}.
+
+handle_info(_Info, StateName, State) ->
+    {next_state, StateName, State}.
+
+terminate(_Reason, _StateName, _State) ->
+    ok.
+
+code_change(_OldVsn, StateName, State, _Extra) ->
+    {ok, StateName, State}.
+

--- a/src/erlzk_heartbeat.erl
+++ b/src/erlzk_heartbeat.erl
@@ -1,8 +1,12 @@
 %%%-------------------------------------------------------------------
 %%% @author kevinbombadil
 %%% @doc
-%%%   receive heartbeats from the erlzk_conn, send a 'no_heartbest'
-%%%   back to it if we've had to wait too long.
+%%%   Given a callback and an interval start a timer.
+%%%   When you receive a beat, reset the timer.
+%%%   When the timer expires run the callback.
+%%%   Note:
+%%%      - We ignore a noproc exit from the callback
+%%%      - This module terminates on timeout
 %%% @end
 %%%-------------------------------------------------------------------
 -module(erlzk_heartbeat).
@@ -10,64 +14,70 @@
 -behaviour(gen_fsm).
 
 %% API
--export([start_link/2, beat/1, no_beat/1]).
+-export([start_link/2, beat/1]).
 
 %% gen_fsm callbacks
 -export([init/1, beating/2, handle_event/3,
-	 handle_sync_event/4, handle_info/3, terminate/3, code_change/4]).
+         handle_sync_event/4, handle_info/3, terminate/3, code_change/4]).
 
 -define(SERVER, ?MODULE).
+-define(NOBEAT, no_beat).
 
--record(state, {connection, interval, timer}).
+-record(state, {callback, interval, timer}).
 
 %%%===================================================================
 %%% API
 %%%===================================================================
-start_link(Connection, PartInterval) ->
-    gen_fsm:start_link(?MODULE, [Connection, PartInterval], []).
+start_link(Callback, Interval) ->
+  gen_fsm:start_link(?MODULE, [Callback, Interval], []).
 
 beat(Pid) ->
-    gen_fsm:send_event(Pid, {beat}).
-
-no_beat(Pid) ->
-    gen_fsm:send_event(Pid, {no_beat}).
-
+  gen_fsm:send_event(Pid, {beat}).
 
 %%%===================================================================
 %%% gen_fsm callbacks
 %%%===================================================================
 
-init([Connection, PartInterval]) ->
-    Interval = PartInterval * 3,
-    Timer=gen_fsm:start_timer(Interval,no_beat),
-    {ok, beating, #state{connection=Connection, 
-			 timer=Timer,
-			 interval=Interval}}.
+init([Callback, Interval]) ->
+  Timer=gen_fsm:start_timer(Interval,?NOBEAT),
+  process_flag(trap_exit, true),
+
+  {ok, beating, #state{callback=Callback,
+                       timer=Timer,
+                       interval=Interval}}.
 %%--------------------------------------------------------------------
 
-beating({beat},State=#state{interval=Interval, timer=Timer}) ->
-    gen_fsm:cancel_timer(Timer),
-    Timer1=gen_fsm:start_timer(Interval,no_beat),
-    {next_state, beating, State#{timer=Timer1}};
+beating({beat},State=#state{interval=Interval,timer=Timer}) ->
+%  error_logger:info_msg("Heartbeat: beat~n"),
+  gen_fsm:cancel_timer(Timer),
+  Timer1 = gen_fsm:start_timer(Interval,{?NOBEAT}),
+  {next_state, beating, State#state{timer=Timer1}};
 
-beating({timeout,_Timer,no_beat},State=#state{Connection=connection}) ->
-    erlzk_conn:no_heartbeat(Connection),
-    {stop,shutdown,State}.
+beating({timeout,_Timer,{?NOBEAT}},State=#state{callback=Callback}) ->
+  error_logger:info_msg("Heartbeat: timeout~n"),
+  try
+    {M,F,A}=Callback,
+    M:F(A)
+  catch exit:{noproc,_} ->
+    ok
+  end,
+  {stop,shutdown,State}.
 
 %%--------------------------------------------------------------------
 handle_event(_Event, StateName, State) ->
-    {next_state, StateName, State}.
+  {next_state, StateName, State}.
 
 handle_sync_event(_Event, _From, StateName, State) ->
-    Reply = ok,
-    {reply, Reply, StateName, State}.
+  Reply = ok,
+  {reply, Reply, StateName, State}.
 
 handle_info(_Info, StateName, State) ->
-    {next_state, StateName, State}.
+  {next_state, StateName, State}.
 
 terminate(_Reason, _StateName, _State) ->
-    ok.
+  ok.
 
 code_change(_OldVsn, StateName, State, _Extra) ->
-    {ok, StateName, State}.
+  {ok, StateName, State}.
 
+%%--------------------------------------------------------------------


### PR DESCRIPTION
kill_session is taken from the java client's function of the same name - its makes it possible to test the 
behaviour when a session is forced to timeout while the connection remains open. 

The heartbeat change ensures that erlzk reconnects when it hasn't heard from the zk server in a given period of time. This is also modeled on the behaviour of the java client