### PR TITLE
Improved connection/reconnection handling, plus minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,10 +88,11 @@ a ping message if no other message sent in a third of negotiated timeout.
 ```
 
 Or you can use `erlzk:connect/3` or `erlzk:connect/4` for more options,
-the options parameter is a `proplists`, support 4 option types:
+the options parameter is a `proplists`, support 5 option types:
 
 + chroot: specify a node under which erlzk will operate on
-+ disable_watch_auto_reset: whether disable reset watches after the session timeout, default is false
++ disable_watch_auto_reset: whether to disable resetting of watches after reconnection, default is false
++ disable_expire_reconnect: whether to disable reconnection after a session has expired, default is false
 + auth_data: the auths need to be added after connected
 + monitor: a process receiving the message of connection state changing
 
@@ -113,7 +114,8 @@ but all ephemeral nodes you created will be deleted by ZooKeeper,
 it's your program's duty to rebuild it, so it's highly recommended to use monitor.
 
 Once connected, erlzk will attempt to stay connected regardless of intermittent connection loss
-or Zookeeper session expiration. Your program can be instructed to drop a connection by calling `erlzk:close/1`:
+or Zookeeper session expiration (unless the option disable_expire_reconnect was supplied with the value
+true. Your program can be instructed to drop a connection by calling `erlzk:close/1`:
 
 ```erlang
 erlzk:close(Pid).

--- a/src/erlzk.erl
+++ b/src/erlzk.erl
@@ -27,7 +27,8 @@
 
 -type server_list() :: [{Host::nonempty_string(), Port::pos_integer()}].
 -type options()     :: [{chroot, nonempty_string()} |
-                        {disable_watch_auto_reset, true | false} |
+                        {disable_watch_auto_reset, boolean()} |
+                        {disable_expire_reconnect, boolean()} |
                         {auth_data, [{Scheme::nonempty_string(), Id::binary()}]} |
                         {monitor, pid()}].
 -type acl()         :: {[perms()], scheme(), id()}.
@@ -78,7 +79,9 @@ connect(ServerName, ServerList, Timeout) when is_integer(Timeout) ->
 %%
 %% <em>chroot</em>: specify a node under which erlzk will operate on
 %%
-%% <em>disable_watch_auto_reset</em>: whether disable reset watches after the connection timeout, default is false
+%% <em>disable_watch_auto_reset</em>: whether to disable resetting of watches after reconnection, default is false
+%%
+%% <em>disable_expire_reconnect</em>: whether to disable reconnection after a session has expired, default is false
 %%
 %% <em>auth_data</em>: the auths need to be added after connected
 %%


### PR DESCRIPTION
We've been using this patched version in heavy production for a while now, and wanted to contribute our improvements back upstream. The main changes relate to improved handling of DNS round-robin, reconnection / expiry, and fixes to kill_session.

* Correctly handle connections to ZooKeeper using DNS names that resolve to multiple IP addresses
  * Resolve round-robin DNS names into list of server IP addresses
* Rotate through server list when connecting, same as Java implementation
  * See StaticHostProvider.java:  StaticHostProvider.next(), StaticHostProvider.onConnected()
* Use 1000ms reconnect timer, like Java implementation does
  * See ClientCnxn.java: ClientCnxn::SendThread.startConnect()
* Only resolve server DNS names on creation, not for every connection attempt, same as Java implementation
* Handle reply timeouts when connecting to ZooKeeper
* Retry connection even if no servers available on initial attempt

* Ignore message for any sockets that aren't related to the current TCP connection

* Never try to send data on a closed socket, and don't attempt calls when not connected

* Improved session expiration handling
  * Reconnect after expire now optional
  * Connection state monitor notified of session expiry as soon as it is detected, and of connection after reconnection

* Notify callers of error when socket an outstanding call was sent on is closed

* Recently added kill_session method was broken, it was using a cast but expecting a call
  * Use gen_server:call for kill_session since we expect to handle_call for kill_session
* Use correct state variable in handle_call for kill_session
* We don't need a heartbeat watcher on TCP connections used purely for kill_session
* TCP connection used for kill_session should not be active, we don't want tcp_closed messages from it

* Use rand module rather than random, so initial seed is not constant and list is shuffled differently each time (18+)
  * random: "The new and improved rand module should be used instead of this module,"

* Use linger option on TCP sockets to improve chances of connection close message being delivered to server

* Refactor duplicated connection closing code into function close_connection