### PR TITLE
initialize ping_interval with infinity

### DIFF
--- a/package.exs
+++ b/package.exs
@@ -3,7 +3,7 @@ defmodule Erlzk.MixFile do
 
   def project do
     [app: :erlzk,
-     version: "0.6.2",
+     version: "0.6.3",
      description: "A Pure Erlang ZooKeeper Client (no C dependency)",
      package: package]
   end

--- a/src/erlzk.app.src
+++ b/src/erlzk.app.src
@@ -1,6 +1,6 @@
 {application, erlzk, [
     {description, "A Pure Erlang ZooKeeper Client (no C dependency)"},
-    {vsn, "0.6.2"},
+    {vsn, "0.6.3"},
     {registered, [erlzk_sup,erlzk_conn_sup]},
     {applications, [
         kernel,

--- a/src/erlzk_conn.erl
+++ b/src/erlzk_conn.erl
@@ -52,7 +52,7 @@
     timeout,
     session_id,
     password,
-    ping_interval,
+    ping_interval = infinity,
     xid = 1,
     zxid = 0,
     reset_watch = true,


### PR DESCRIPTION
This is to handle situation when zookeeper is not available when
erlzk_conn process starts. In this case ping_interval in state will be
'undefined', and the next incoming request will trigger a handle_call
callback which returns {ok, State, PingInt} to gen_server. The process
will crash in the main gen_server loop function on receive ... after
because Time will be 'undefined'.

By setting ping_interval to infinity we just emulate default behaviour.