### PR TITLE
Fix function clause crash in notify_callers_closed when watch exists

### DIFF
--- a/package.exs
+++ b/package.exs
@@ -3,7 +3,7 @@ defmodule Erlzk.MixFile do
 
   def project do
     [app: :erlzk,
-     version: "0.6.5",
+     version: "0.6.6",
      description: "A Pure Erlang ZooKeeper Client (no C dependency)",
      package: package]
   end

--- a/src/erlzk.app.src
+++ b/src/erlzk.app.src
@@ -1,6 +1,6 @@
 {application, erlzk, [
     {description, "A Pure Erlang ZooKeeper Client (no C dependency)"},
-    {vsn, "0.6.5"},
+    {vsn, "0.6.6"},
     {registered, [erlzk_sup,erlzk_conn_sup]},
     {applications, [
         kernel,


### PR DESCRIPTION
* Add clause to notify_callers_closed handling reqs entry containing watch
* Also handle exit:noproc from erlzk_heartbeat:stop, as this masks the crash
  above after erlzk_heartbeat calls erlzk_conn:no_heartbeat and exits. This
  fix also applies to other race conditions such as TCP connection closing at
  the same time as a heartbeat times out.