### PR TITLE
Supply read-only=false flag when connecting

### DIFF
--- a/src/erlzk_conn.erl
+++ b/src/erlzk_conn.erl
@@ -398,11 +398,11 @@ connect([Server={Host,Port}|Left], ProtocolVersion, LastZxidSeen, Timeout, LastS
     case gen_tcp:connect(Host, Port, ?ZK_SOCKET_OPTS, ?ZK_CONNECT_TIMEOUT) of
         {ok, Socket} ->
             error_logger:info_msg("Connected ~p:~p, sending connect command~n", [Host, Port]),
-            case gen_tcp:send(Socket, erlzk_codec:pack(connect, {ProtocolVersion, LastZxidSeen, Timeout, LastSessionId, LastPassword})) of
+            case gen_tcp:send(Socket, erlzk_codec:pack(connect, {ProtocolVersion, LastZxidSeen, Timeout, LastSessionId, LastPassword, false})) of
                 ok ->
                     receive
                         {tcp, Socket, Packet} ->
-                            {ProtoVer, RealTimeOut, SessionId, Password} = erlzk_codec:unpack(connect, Packet),
+                            {ProtoVer, RealTimeOut, SessionId, Password, false} = erlzk_codec:unpack(connect, Packet),
                             case SessionId of
                                 0 ->
                                     error_logger:warning_msg("Session expired, connection to ~p:~p will be closed~n", [Host, Port]),


### PR DESCRIPTION
* Not a full implementation of read-only with read-only==true handling.
* Avoids the logging of a warning message whenever erlzk connects
  "Connection request from old client {}; will be dropped if server is in r-o mode"
  https://github.com/apache/zookeeper/blob/master/zookeeper-server/src/main/java/org/apache/zookeeper/server/ZooKeeperServer.java#L1403
* Server-side support for read-only added in ZooKeeper 3.4.0 (22 Nov 2011)
  https://issues.apache.org/jira/browse/ZOOKEEPER-784 https://github.com/apache/zookeeper/commit/9be9a3a1
* C client support for read-only added in ZooKeeper 3.5.0 (6 Aug 2014)
  https://issues.apache.org/jira/browse/ZOOKEEPER-827 https://github.com/apache/zookeeper/commit/dc40617c
* Backwards compatible with older servers
  https://cwiki.apache.org/confluence/display/HADOOP2/ZooKeeper+GSoCReadOnlyMode